### PR TITLE
What if `ssrEmitAssets = false`?

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+Reproduction for
+
+- https://github.com/remix-run/remix/issues/8041
+
+```sh
+$ pnpm build
+...
+
+✓ 7 modules transformed.
+build/.vite/manifest.json                       0.31 kB
+build/index.js                                  0.13 kB
+build/assets/_virtual_server-entry-a9O7knL0.js  6.74 kB
+✓ built in 120ms
+
+
+$ node build/index.js
+node:internal/errors:490
+    ErrorCaptureStackTrace(err);
+    ^
+
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/home/hiroshi/code/tmp/repro-8041/build/assets/_virtual_server-entry-a9O7knL0.js' imported from /home/hiroshi/code/tmp/repro-8041/build/index.js
+    at new NodeError (node:internal/errors:399:5)
+    at finalizeResolution (node:internal/modules/esm/resolve:326:11)
+    at moduleResolve (node:internal/modules/esm/resolve:945:10)
+    at defaultResolve (node:internal/modules/esm/resolve:1153:11)
+    at nextResolve (node:internal/modules/esm/loader:163:28)
+    at ESMLoader.resolve (node:internal/modules/esm/loader:838:30)
+    at ESMLoader.getModuleJob (node:internal/modules/esm/loader:424:18)
+```
+
+---
+
 # templates/unstable-vite
 
 ⚠️ Remix support for Vite is unstable and not recommended for production.

--- a/app/demo.ts
+++ b/app/demo.ts
@@ -1,0 +1,7 @@
+async function main() {
+  // @ts-ignore
+  const demo = await import("virtual:server-entry");
+  console.log(demo);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -29,5 +29,10 @@
   },
   "engines": {
     "node": ">=18.0.0"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "@remix-run/dev@2.3.0": "patches/@remix-run__dev@2.3.0.patch"
+    }
   }
 }

--- a/patches/@remix-run__dev@2.3.0.patch
+++ b/patches/@remix-run__dev@2.3.0.patch
@@ -1,0 +1,21 @@
+diff --git a/dist/vite/plugin.js b/dist/vite/plugin.js
+index 2a9bc7066ecd3819b9dd490d6a8cb543682cdbfa..d0c3e4851675c01233d82d8158a0d273acf48b48 100644
+--- a/dist/vite/plugin.js
++++ b/dist/vite/plugin.js
+@@ -386,7 +386,7 @@ const remixVitePlugin = (options = {}) => {
+                 input: [pluginConfig.entryClientFilePath, ...Object.values(pluginConfig.routes).map(route => path__namespace.resolve(pluginConfig.appDirectory, route.file))]
+               }
+             } : {
+-              ssrEmitAssets: true,
++              ssrEmitAssets: false,
+               // We move SSR-only assets to client assets and clean the rest
+               manifest: true,
+               // We need the manifest to detect SSR-only assets
+@@ -555,6 +555,7 @@ const remixVitePlugin = (options = {}) => {
+       // After the SSR build is finished, we inspect the Vite manifest for
+       // the SSR build and move all server assets to client assets directory
+       async handler() {
++        return;
+         if (!ssrBuildContext.isSsrBuild) {
+           return;
+         }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@remix-run/dev@2.3.0':
+    hash: ghjud3l6njw4agpqpt2xcafcba
+    path: patches/@remix-run__dev@2.3.0.patch
+
 dependencies:
   '@remix-run/node':
     specifier: ^2.3.0
@@ -27,7 +32,7 @@ dependencies:
 devDependencies:
   '@remix-run/dev':
     specifier: ^2.3.0
-    version: 2.3.0(@remix-run/serve@2.3.0)(typescript@5.2.2)(vite@5.0.0)
+    version: 2.3.0(patch_hash=ghjud3l6njw4agpqpt2xcafcba)(@remix-run/serve@2.3.0)(typescript@5.2.2)(vite@5.0.0)
   '@remix-run/eslint-config':
     specifier: ^2.3.0
     version: 2.3.0(eslint@8.53.0)(react@18.2.0)(typescript@5.2.2)
@@ -1278,7 +1283,7 @@ packages:
     dev: true
     optional: true
 
-  /@remix-run/dev@2.3.0(@remix-run/serve@2.3.0)(typescript@5.2.2)(vite@5.0.0):
+  /@remix-run/dev@2.3.0(patch_hash=ghjud3l6njw4agpqpt2xcafcba)(@remix-run/serve@2.3.0)(typescript@5.2.2)(vite@5.0.0):
     resolution: {integrity: sha512-Eno0XHyIKo5GyzN4OAwNkgkyl4H1mLWbqeVUA8T5HmVDj+8qJLIcYeayS2BmA1KYAHJBiy5ufAGi2MpaXMjKww==}
     engines: {node: '>=18.0.0'}
     hasBin: true
@@ -1368,6 +1373,7 @@ packages:
       - ts-node
       - utf-8-validate
     dev: true
+    patched: true
 
   /@remix-run/eslint-config@2.3.0(eslint@8.53.0)(react@18.2.0)(typescript@5.2.2):
     resolution: {integrity: sha512-iyuNO7tRjevLjwGH4nLv/6g5NROhUXIQHTNjTUhQjEkHac4/kp3EOnnQEtGmMUfLruTyz6OoOJQzTkT3l14VvQ==}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,23 @@ import { defineConfig } from "vite";
 import tsconfigPaths from "vite-tsconfig-paths";
 
 export default defineConfig({
-  plugins: [remix(), tsconfigPaths()],
+  plugins: [
+    remix(),
+    tsconfigPaths(),
+    // overwrite remix's default ssr build entry
+    {
+      name: "overwrite-remix-server-entry",
+      config(config, env) {
+        if (env.command === "build" && config.build?.ssr) {
+          return {
+            build: {
+              rollupOptions: {
+                input: "./app/demo.ts",
+              },
+            },
+          };
+        }
+      },
+    },
+  ],
 });


### PR DESCRIPTION
Indeed, it looks like code-split server entry was emitted under `assets` regardless of `ssrEmitAssets`.

```
$ pnpm build
...
✓ 7 modules transformed.
build/.vite/manifest.json              0.31 kB
build/assets/server-split-iBm_D6Kf.js  0.06 kB
build/index.js                         6.87 kB
✓ built in 110ms
```